### PR TITLE
Feat: "메뉴 전체보기 화면 구현"

### DIFF
--- a/lib/screens/menu/menu_bottom_sheet.dart
+++ b/lib/screens/menu/menu_bottom_sheet.dart
@@ -60,11 +60,15 @@ class MenuBottomSheet extends StatelessWidget {
                 ),
               ),
               if (viewModel.isExpanded)
-                Column(
-                  children: [
-                    for (var menu in viewModel.selectedMenu)
-                      MenuBottomSheetCard(menu: menu),
-                  ],
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      children: [
+                        for (var menu in viewModel.selectedMenu)
+                          MenuBottomSheetCard(menu: menu),
+                      ],
+                    ),
+                  ),
                 ),
               Container(
                 padding: const EdgeInsets.only(

--- a/lib/screens/menu/menu_bottom_sheet.dart
+++ b/lib/screens/menu/menu_bottom_sheet.dart
@@ -80,7 +80,7 @@ class MenuBottomSheet extends StatelessWidget {
                 height: 77,
                 child: Row(
                   children: [
-                    if (!viewModel.isExpanded)
+                    if (!viewModel.isExpanded && !viewModel.isHideCounter)
                       CountWidget(
                         count:
                             viewModel.selectedMenuQty[viewModel.mainItem?.id] ??
@@ -90,7 +90,8 @@ class MenuBottomSheet extends StatelessWidget {
                             viewModel.minusMenu(viewModel.mainItem!),
                         size: CountWidgetSize.large,
                       ),
-                    if (!viewModel.isExpanded) const SizedBox(width: 10),
+                    if (!viewModel.isExpanded && !viewModel.isHideCounter)
+                      const SizedBox(width: 10),
                     Flexible(
                       flex: 1,
                       child: Container(

--- a/lib/screens/menu/menu_bottom_sheet_view_model.dart
+++ b/lib/screens/menu/menu_bottom_sheet_view_model.dart
@@ -6,6 +6,7 @@ class MenuBottomSheetViewModel with ChangeNotifier {
   final List<Menu> _selectedMenu = [];
   final Map<int, int> _selectedMenuQty = {};
   bool _isExpanded = false;
+  bool _isHideCounter = false;
 
   MenuBottomSheetViewModel();
 
@@ -13,6 +14,7 @@ class MenuBottomSheetViewModel with ChangeNotifier {
   List<Menu> get selectedMenu => _selectedMenu;
   Map<int, int> get selectedMenuQty => _selectedMenuQty;
   bool get isExpanded => _isExpanded;
+  bool get isHideCounter => _isHideCounter;
 
   void setMainItem(Menu menu) {
     if (_mainItem != null) return;
@@ -65,6 +67,16 @@ class MenuBottomSheetViewModel with ChangeNotifier {
 
   void shrink() {
     _isExpanded = false;
+    notifyListeners();
+  }
+
+  void hideCounter() {
+    _isHideCounter = true;
+    notifyListeners();
+  }
+
+  void revealCounter() {
+    _isHideCounter = false;
     notifyListeners();
   }
 }

--- a/lib/screens/menu/menu_more_view.dart
+++ b/lib/screens/menu/menu_more_view.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:immersion_kwangsang/models/menu.dart';
+import 'package:immersion_kwangsang/screens/menu/menu_bottom_sheet.dart';
+import 'package:immersion_kwangsang/screens/menu/menu_bottom_sheet_view_model.dart';
+import 'package:immersion_kwangsang/screens/menu/menu_more_view_model.dart';
+import 'package:immersion_kwangsang/styles/color.dart';
+import 'package:immersion_kwangsang/styles/txt.dart';
+import 'package:immersion_kwangsang/widgets/countable_menu_card.dart';
+import 'package:provider/provider.dart';
+
+class MenuMoreView extends StatelessWidget {
+  const MenuMoreView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    var bottomSheetModel = context.read<MenuBottomSheetViewModel>();
+    return Scaffold(
+      backgroundColor: KwangColor.grey100,
+      appBar: AppBar(
+        title: Text("메뉴 전체보기", style: KwangStyle.header2),
+        toolbarHeight: 52,
+        titleSpacing: 8,
+        centerTitle: false,
+        leading: Padding(
+          padding: const EdgeInsets.only(left: 8),
+          child: GestureDetector(
+            onTap: () {
+              Navigator.of(context).pop();
+            },
+            child: SvgPicture.asset(
+              "assets/icons/ic_36_back.svg",
+              width: 36,
+              height: 36,
+            ),
+          ),
+        ),
+        leadingWidth: 44,
+        backgroundColor: Colors.white,
+        surfaceTintColor: Colors.transparent,
+        elevation: 0,
+      ),
+      body: Column(
+        children: [
+          SingleChildScrollView(
+            padding: const EdgeInsets.only(
+              left: 20,
+              right: 10,
+              bottom: 20,
+              top: 6,
+            ),
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: [
+                for (var option in EMenuMoreSortOption.values)
+                  _sortOptionBtn(
+                    option,
+                    isSelected: option == EMenuMoreSortOption.favorite,
+                    onTap: () {},
+                  ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView.separated(
+              padding: EdgeInsets.only(
+                bottom: 110 + MediaQuery.paddingOf(context).bottom,
+              ),
+              itemBuilder: (context, index) {
+                var menuMock = Menu(
+                  id: 100 + index,
+                  name: '메뉴 ${index + 1}',
+                  imgUrl:
+                      "https://lh4.googleusercontent.com/on7Yj1rShJRRBy88rTmptLVzMI4gEBDBabmSMv-GGsPIo5umfS5dpSJp3b4EoqKtnxdOYXeHSyct6m2fLYKckaikrUJn91PNWkIYXtkrCljcvdEnGdf_nQM5Qw6bQY4q6jvbWiBcC3WPTIcDS_lizv3R25oVAF_H0PNzvRo7JivPSiZR",
+                  discountRate: 10,
+                  regularPrice: 11000,
+                  discountPrice: 10000,
+                );
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: CountableMenuCard(
+                    menu: menuMock,
+                    type: CMenuCardType.large,
+                    add: () {
+                      bottomSheetModel.plusMenu(menuMock);
+                    },
+                    subtract: () {
+                      bottomSheetModel.minusMenu(menuMock);
+                    },
+                  ),
+                );
+              },
+              separatorBuilder: (context, index) => Container(
+                margin: const EdgeInsets.all(20),
+                width: double.infinity,
+                height: 1,
+                color: KwangColor.grey350,
+              ),
+              itemCount: 10,
+            ),
+          ),
+        ],
+      ),
+      bottomSheet: const MenuBottomSheet(),
+    );
+  }
+
+  Widget _sortOptionBtn(
+    EMenuMoreSortOption option, {
+    bool isSelected = false,
+    required Function() onTap,
+  }) {
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.translucent,
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: 14,
+          vertical: 10,
+        ),
+        margin: const EdgeInsets.only(right: 10),
+        decoration: BoxDecoration(
+          color: isSelected ? KwangColor.primary400 : KwangColor.grey300,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Center(
+          child: Text(
+            option.text,
+            style: KwangStyle.btn2B.copyWith(
+              color: isSelected ? Colors.white : KwangColor.grey600,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/menu/menu_more_view_model.dart
+++ b/lib/screens/menu/menu_more_view_model.dart
@@ -1,0 +1,12 @@
+enum EMenuMoreSortOption {
+  favorite('인기 많은 순'),
+  lowPrice('가격 낮은 순'),
+  highDiscount('할인율 높은 순'),
+  longDuration('소비기한 긴 순');
+
+  final String text;
+
+  const EMenuMoreSortOption(this.text);
+}
+
+// TODO: implement view model

--- a/lib/screens/menu/menu_view.dart
+++ b/lib/screens/menu/menu_view.dart
@@ -8,6 +8,7 @@ import 'package:immersion_kwangsang/models/menu.dart';
 import 'package:immersion_kwangsang/screens/map/widgets/store_info_row.dart';
 import 'package:immersion_kwangsang/screens/menu/menu_bottom_sheet.dart';
 import 'package:immersion_kwangsang/screens/menu/menu_bottom_sheet_view_model.dart';
+import 'package:immersion_kwangsang/screens/menu/menu_more_view.dart';
 import 'package:immersion_kwangsang/screens/menu/menu_view_model.dart';
 import 'package:immersion_kwangsang/services/amplitude.dart';
 import 'package:immersion_kwangsang/styles/color.dart';
@@ -248,8 +249,38 @@ class MenuView extends StatelessWidget {
                           Padding(
                               padding: const EdgeInsets.symmetric(
                                   vertical: 16, horizontal: 20),
-                              child: Text("이 매장 또 다른 메뉴",
-                                  style: KwangStyle.header2)),
+                              child: Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Text("이 매장 또 다른 메뉴",
+                                      style: KwangStyle.header2),
+                                  GestureDetector(
+                                    onTap: () async {
+                                      var bottomSheetModel = context
+                                          .read<MenuBottomSheetViewModel>();
+                                      bottomSheetModel.hideCounter();
+                                      await Navigator.of(context).push(
+                                        MaterialPageRoute(
+                                          builder: (_) =>
+                                              ChangeNotifierProvider.value(
+                                            value: Provider.of<
+                                                    MenuBottomSheetViewModel>(
+                                                context),
+                                            child: const MenuMoreView(),
+                                          ),
+                                        ),
+                                      );
+                                      bottomSheetModel.revealCounter();
+                                    },
+                                    child: Text(
+                                      "메뉴 전체보기",
+                                      style: KwangStyle.btn3
+                                          .copyWith(color: KwangColor.grey600),
+                                    ),
+                                  ),
+                                ],
+                              )),
                         if (viewModel.menu!.anotherMenus.isNotEmpty)
                           Padding(
                             padding: const EdgeInsets.symmetric(
@@ -276,12 +307,17 @@ class MenuView extends StatelessWidget {
                                   );
                                   await Navigator.of(context).push(
                                     MaterialPageRoute(
-                                      builder: (_) => ChangeNotifierProvider(
-                                        create: (_) => MenuViewModel(viewModel
-                                            .menu!.anotherMenus[idx].id),
-                                        child: MenuView(
-                                            menuId: viewModel
-                                                .menu!.anotherMenus[idx].id),
+                                      builder: (_) =>
+                                          ChangeNotifierProvider.value(
+                                        value: Provider.of<
+                                            MenuBottomSheetViewModel>(context),
+                                        child: ChangeNotifierProvider(
+                                          create: (_) => MenuViewModel(viewModel
+                                              .menu!.anotherMenus[idx].id),
+                                          child: MenuView(
+                                              menuId: viewModel
+                                                  .menu!.anotherMenus[idx].id),
+                                        ),
                                       ),
                                     ),
                                   );


### PR DESCRIPTION
### 개요

상품상세 화면에서 할인율이 가장 높은 메뉴 카드의 메뉴 전체보기 탭 시 라우트되는
메뉴 전체보기 화면을 구현 완료했습니다.

Resolves: #24

### 추가사항

- 메뉴 전체보기 화면 구현
- 담은 상품 바텀시트와 연동 확인

### 변경사항 및 이유

- menu_bottom_sheet_view
  메뉴를 많이 담을 때 위젯 오버플로가 일어나서 위젯 레이아웃이 약간 수정되었습니다.

- menu_view
  Line 310~320에 menu_bottom_sheet_view_model을 위해 프로바이터 코드가 추가되었습니다.
