### PR TITLE
Feat: "주문 내역 화면 구현"

### DIFF
--- a/lib/screens/menu/menu_bottom_sheet.dart
+++ b/lib/screens/menu/menu_bottom_sheet.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:immersion_kwangsang/screens/menu/menu_bottom_sheet_view_model.dart';
 import 'package:immersion_kwangsang/screens/menu/widgets/menu_bottom_sheet_card.dart';
+import 'package:immersion_kwangsang/screens/purchase_info/purchase_info_view.dart';
+import 'package:immersion_kwangsang/screens/purchase_info/purchase_info_view_model.dart';
 import 'package:immersion_kwangsang/styles/color.dart';
 import 'package:immersion_kwangsang/styles/txt.dart';
 import 'package:immersion_kwangsang/widgets/count_widget.dart';
@@ -89,16 +92,30 @@ class MenuBottomSheet extends StatelessWidget {
                     if (!viewModel.isExpanded) const SizedBox(width: 10),
                     Flexible(
                       flex: 1,
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: KwangColor.primary400,
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Center(
-                          child: Text(
-                            '${NumberFormat('###,###,###,###').format(viewModel.totalCost())}원 주문하기',
-                            style:
-                                KwangStyle.btn2B.copyWith(color: Colors.white),
+                      child: GestureDetector(
+                        // TODO: Temporary routing to purchase info screem
+                        onTap: () {
+                          Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => ChangeNotifierProvider(
+                                create: (_) =>
+                                    PurchaseInfoViewModel(isMember: true),
+                                child: const PurchaseInfoView(),
+                              ),
+                            ),
+                          );
+                        },
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: KwangColor.primary400,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Center(
+                            child: Text(
+                              '${NumberFormat('###,###,###,###').format(viewModel.totalCost())}원 주문하기',
+                              style: KwangStyle.btn2B
+                                  .copyWith(color: Colors.white),
+                            ),
                           ),
                         ),
                       ),

--- a/lib/screens/purchase_info/purchase_info_view.dart
+++ b/lib/screens/purchase_info/purchase_info_view.dart
@@ -5,6 +5,7 @@ import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_
 import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_detail.dart';
 import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_map.dart';
 import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_map_detail.dart';
+import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_method.dart';
 import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_progress_widget.dart';
 import 'package:immersion_kwangsang/styles/color.dart';
 import 'package:immersion_kwangsang/styles/txt.dart';
@@ -57,10 +58,54 @@ class PurchaseInfoView extends StatelessWidget {
             const PurchaseInfoCardHSpliter(),
             const PurchaseInfoDetail(),
             const PurchaseInfoCardHSpliter(),
+            const PurchaseInfoMethod(),
             SizedBox(height: MediaQuery.paddingOf(context).bottom),
+            if (viewModel.phase == EPurchaseInfoPhase.pending)
+              const SizedBox(height: 90),
           ],
         ),
       ),
+      bottomSheet: viewModel.phase == EPurchaseInfoPhase.pending
+          ? Container(
+              height: 84 + MediaQuery.paddingOf(context).bottom,
+              padding: const EdgeInsets.only(
+                left: 20,
+                right: 20,
+                top: 20,
+              ),
+              decoration: const BoxDecoration(
+                color: Colors.white,
+                boxShadow: [
+                  BoxShadow(
+                    blurRadius: 1,
+                    spreadRadius: 3,
+                    color: KwangColor.grey300,
+                  ),
+                ],
+              ),
+              child: Align(
+                alignment: Alignment.topCenter,
+                child: GestureDetector(
+                  onTap: () {},
+                  child: Container(
+                    height: 52,
+                    decoration: BoxDecoration(
+                      color: KwangColor.primary100,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Center(
+                      child: Text(
+                        '주문 취소',
+                        style: KwangStyle.btn2B.copyWith(
+                          color: KwangColor.primary400,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            )
+          : null,
     );
   }
 }

--- a/lib/screens/purchase_info/purchase_info_view.dart
+++ b/lib/screens/purchase_info/purchase_info_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:immersion_kwangsang/screens/purchase_info/purchase_info_view_model.dart';
 import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_card_h_spliter.dart';
+import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_map.dart';
 import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_progress_widget.dart';
 import 'package:immersion_kwangsang/styles/color.dart';
 import 'package:immersion_kwangsang/styles/txt.dart';
@@ -43,6 +44,8 @@ class PurchaseInfoView extends StatelessWidget {
       body: const Column(
         children: [
           PurchaseInfoProgressWidget(),
+          PurchaseInfoCardHSpliter(),
+          PurchaseInfoMap(),
           PurchaseInfoCardHSpliter(),
         ],
       ),

--- a/lib/screens/purchase_info/purchase_info_view.dart
+++ b/lib/screens/purchase_info/purchase_info_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:immersion_kwangsang/screens/purchase_info/purchase_info_view_model.dart';
 import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_card_h_spliter.dart';
+import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_detail.dart';
 import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_map.dart';
 import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_map_detail.dart';
 import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_progress_widget.dart';
@@ -53,6 +54,8 @@ class PurchaseInfoView extends StatelessWidget {
                 viewModel.phase == EPurchaseInfoPhase.pickup)
               const PurchaseInfoMapDetail(),
             const SizedBox(height: 6),
+            const PurchaseInfoCardHSpliter(),
+            const PurchaseInfoDetail(),
             const PurchaseInfoCardHSpliter(),
             SizedBox(height: MediaQuery.paddingOf(context).bottom),
           ],

--- a/lib/screens/purchase_info/purchase_info_view.dart
+++ b/lib/screens/purchase_info/purchase_info_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:immersion_kwangsang/screens/purchase_info/purchase_info_view_model.dart';
 import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_card_h_spliter.dart';
 import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_map.dart';
+import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_map_detail.dart';
 import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_progress_widget.dart';
 import 'package:immersion_kwangsang/styles/color.dart';
 import 'package:immersion_kwangsang/styles/txt.dart';
@@ -39,15 +40,23 @@ class PurchaseInfoView extends StatelessWidget {
         ),
         leadingWidth: 44,
         backgroundColor: Colors.white,
+        surfaceTintColor: Colors.transparent,
         elevation: 0,
       ),
-      body: const Column(
-        children: [
-          PurchaseInfoProgressWidget(),
-          PurchaseInfoCardHSpliter(),
-          PurchaseInfoMap(),
-          PurchaseInfoCardHSpliter(),
-        ],
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            const PurchaseInfoProgressWidget(),
+            const PurchaseInfoCardHSpliter(),
+            const PurchaseInfoMap(),
+            if (viewModel.phase == EPurchaseInfoPhase.accepted ||
+                viewModel.phase == EPurchaseInfoPhase.pickup)
+              const PurchaseInfoMapDetail(),
+            const SizedBox(height: 6),
+            const PurchaseInfoCardHSpliter(),
+            SizedBox(height: MediaQuery.paddingOf(context).bottom),
+          ],
+        ),
       ),
     );
   }

--- a/lib/screens/purchase_info/purchase_info_view.dart
+++ b/lib/screens/purchase_info/purchase_info_view.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:immersion_kwangsang/screens/purchase_info/purchase_info_view_model.dart';
+import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_card_h_spliter.dart';
+import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_progress_widget.dart';
+import 'package:immersion_kwangsang/styles/color.dart';
+import 'package:immersion_kwangsang/styles/txt.dart';
+import 'package:provider/provider.dart';
+
+class PurchaseInfoView extends StatelessWidget {
+  const PurchaseInfoView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = Provider.of<PurchaseInfoViewModel>(context);
+    return Scaffold(
+      backgroundColor: KwangColor.grey100,
+      appBar: AppBar(
+        title: Text(
+          viewModel.isMember ? '주문 내역' : '비회원 주문 조회',
+          style: KwangStyle.header2,
+        ),
+        toolbarHeight: 52,
+        titleSpacing: 8,
+        centerTitle: false,
+        leading: Padding(
+          padding: const EdgeInsets.only(left: 8),
+          child: GestureDetector(
+            onTap: () {
+              Navigator.of(context).pop();
+            },
+            child: SvgPicture.asset(
+              "assets/icons/ic_36_back.svg",
+              width: 36,
+              height: 36,
+            ),
+          ),
+        ),
+        leadingWidth: 44,
+        backgroundColor: Colors.white,
+        elevation: 0,
+      ),
+      body: const Column(
+        children: [
+          PurchaseInfoProgressWidget(),
+          PurchaseInfoCardHSpliter(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/purchase_info/purchase_info_view_model.dart
+++ b/lib/screens/purchase_info/purchase_info_view_model.dart
@@ -17,6 +17,7 @@ enum EPurchaseInfoPhase {
 
 class PurchaseInfoViewModel extends ChangeNotifier {
   late final bool _isMember;
+  // TODO: Initialize with API
   EPurchaseInfoPhase _phase = EPurchaseInfoPhase.pending;
 
   PurchaseInfoViewModel({

--- a/lib/screens/purchase_info/purchase_info_view_model.dart
+++ b/lib/screens/purchase_info/purchase_info_view_model.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/foundation.dart';
+
+enum EPurchaseInfoPhase {
+  pending('주문 요청', '주문 승인 대기 중이에요'),
+  accepted('주문 승인', '주문이 승인되었어요'),
+  pickup('픽업 대기', '상품이 준비되어 픽업을 기다리고 있어요'),
+  completed('픽업 완료', '픽업이 완료되었어요, 맛있게 드세요!');
+
+  final String progressText;
+  final String phaseTitle;
+
+  const EPurchaseInfoPhase(
+    this.progressText,
+    this.phaseTitle,
+  );
+}
+
+class PurchaseInfoViewModel extends ChangeNotifier {
+  late final bool _isMember;
+  EPurchaseInfoPhase _phase = EPurchaseInfoPhase.pending;
+
+  PurchaseInfoViewModel({
+    required bool isMember,
+  }) : _isMember = isMember;
+
+  bool get isMember => _isMember;
+  EPurchaseInfoPhase get phase => _phase;
+
+  // TODO: hide interface - will chage automatically
+  void changePhase(EPurchaseInfoPhase phase) {
+    _phase = phase;
+    notifyListeners();
+  }
+}

--- a/lib/screens/purchase_info/widgets/purchase_info_card_h_spliter.dart
+++ b/lib/screens/purchase_info/widgets/purchase_info_card_h_spliter.dart
@@ -2,13 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:immersion_kwangsang/styles/color.dart';
 
 class PurchaseInfoCardHSpliter extends StatelessWidget {
-  const PurchaseInfoCardHSpliter({super.key});
+  final double size;
+
+  const PurchaseInfoCardHSpliter({
+    super.key,
+    this.size = 4,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Container(
       width: double.infinity,
-      height: 4,
+      height: size,
       color: KwangColor.grey200,
     );
   }

--- a/lib/screens/purchase_info/widgets/purchase_info_card_h_spliter.dart
+++ b/lib/screens/purchase_info/widgets/purchase_info_card_h_spliter.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:immersion_kwangsang/styles/color.dart';
+
+class PurchaseInfoCardHSpliter extends StatelessWidget {
+  const PurchaseInfoCardHSpliter({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      height: 4,
+      color: KwangColor.grey200,
+    );
+  }
+}

--- a/lib/screens/purchase_info/widgets/purchase_info_detail.dart
+++ b/lib/screens/purchase_info/widgets/purchase_info_detail.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:immersion_kwangsang/models/menu.dart';
+import 'package:immersion_kwangsang/screens/purchase_info/purchase_info_view_model.dart';
+import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_card_h_spliter.dart';
+import 'package:immersion_kwangsang/styles/color.dart';
+import 'package:immersion_kwangsang/styles/txt.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+class PurchaseInfoDetail extends StatelessWidget {
+  const PurchaseInfoDetail({super.key});
+
+  // TODO: delete mocking data
+  static List<Menu> items = [
+    for (int i = 0; i < 3; i++)
+      Menu(
+        id: 1,
+        name: 'Menu $i',
+        imgUrl: 'imgUrl',
+        discountRate: 10,
+        regularPrice: 10000,
+        discountPrice: 9000,
+      ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = Provider.of<PurchaseInfoViewModel>(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: 20,
+        vertical: 16,
+      ),
+      child: Column(
+        children: [
+          const SizedBox(height: 8),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '상세 주문 내역',
+                style: KwangStyle.header2,
+              ),
+              Text(
+                'No.${123456}',
+                style: KwangStyle.btn1SB.copyWith(
+                  color: KwangColor.grey700,
+                ),
+              ),
+            ],
+          ),
+          for (var item in items)
+            _item(
+              name: item.name,
+              regularPrice: item.regularPrice!,
+              discountPrice: item.discountPrice,
+              qty: 1,
+            ),
+          const SizedBox(height: 18),
+          const PurchaseInfoCardHSpliter(size: 1),
+          const SizedBox(height: 18),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '총 결제 금액',
+                style: KwangStyle.header3,
+              ),
+              Row(
+                children: [
+                  Text(
+                    '${NumberFormat(
+                      '###,###,###,###',
+                    ).format(
+                          items.fold(0, (prev, e) => prev + e.regularPrice!),
+                        ).replaceAll(' ', ',')}원',
+                    style: KwangStyle.header3.copyWith(
+                      color: KwangColor.grey500,
+                      decoration: TextDecoration.lineThrough,
+                      decorationColor: KwangColor.grey500,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    '${NumberFormat(
+                      '###,###,###,###',
+                    ).format(
+                          items.fold(0, (prev, e) => prev + e.discountPrice),
+                        ).replaceAll(' ', ',')}원',
+                    style: KwangStyle.header3.copyWith(
+                      color: KwangColor.grey800,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 18),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '총 할인 금액',
+                style: KwangStyle.body1M,
+              ),
+              Row(
+                children: [
+                  Text(
+                    '-${NumberFormat(
+                      '###,###,###,###',
+                    ).format(
+                          items.fold(0, (prev, e) => prev + e.regularPrice!) -
+                              items.fold(
+                                  0, (prev, e) => prev + e.discountPrice),
+                        ).replaceAll(' ', ',')}원',
+                    style: KwangStyle.btn2SB.copyWith(
+                      color: KwangColor.red,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+        ],
+      ),
+    );
+  }
+
+  Widget _item({
+    required String name,
+    required int qty,
+    required int regularPrice,
+    required int discountPrice,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 18),
+      child: Row(
+        children: [
+          Flexible(
+            child: Row(
+              children: [
+                Flexible(
+                  child: Text(
+                    name,
+                    style: KwangStyle.body1M.copyWith(
+                      color: KwangColor.grey800,
+                    ),
+                  ),
+                ),
+                Text(
+                  ' x $qty',
+                  style: KwangStyle.body1M.copyWith(
+                    color: KwangColor.grey800,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 10),
+          Row(
+            children: [
+              Text(
+                '${NumberFormat('###,###,###,###').format(regularPrice).replaceAll(' ', ',')}원',
+                style: KwangStyle.body1M.copyWith(
+                  color: KwangColor.grey500,
+                  decoration: TextDecoration.lineThrough,
+                  decorationColor: KwangColor.grey500,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '${NumberFormat('###,###,###,###').format(discountPrice).replaceAll(' ', ',')}원',
+                style: KwangStyle.body1M.copyWith(
+                  color: KwangColor.grey800,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/purchase_info/widgets/purchase_info_map.dart
+++ b/lib/screens/purchase_info/widgets/purchase_info_map.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:immersion_kwangsang/screens/purchase_info/purchase_info_view_model.dart';
+import 'package:immersion_kwangsang/styles/color.dart';
+import 'package:immersion_kwangsang/styles/txt.dart';
+import 'package:provider/provider.dart';
+
+class PurchaseInfoMap extends StatelessWidget {
+  const PurchaseInfoMap({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = Provider.of<PurchaseInfoViewModel>(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: 8),
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: 20,
+            vertical: 16,
+          ),
+          child: Text(
+            viewModel.phase == EPurchaseInfoPhase.pending ||
+                    viewModel.phase == EPurchaseInfoPhase.completed
+                ? '가게 정보'
+                : '픽업 전 다시 한번 확인하세요',
+            style: KwangStyle.header2,
+          ),
+        ),
+        const SizedBox(height: 8),
+        if (viewModel.phase != EPurchaseInfoPhase.completed)
+          Container(
+            width: MediaQuery.of(context).size.width - 40,
+            margin: const EdgeInsets.only(
+              left: 20,
+              right: 20,
+              bottom: 18,
+            ),
+            decoration: BoxDecoration(
+              border: Border.all(
+                color: KwangColor.grey300,
+                width: 1,
+              ),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            clipBehavior: Clip.hardEdge,
+            height: 132,
+            // TODO: connect with viewModel
+            child: GoogleMap(
+              initialCameraPosition: const CameraPosition(
+                // target: viewModel.menu!.store.latLng,
+                target: LatLng(37.6203769557633, 127.057749200082),
+                zoom: 16,
+              ),
+              myLocationButtonEnabled: false,
+              zoomControlsEnabled: false,
+              gestureRecognizers: {
+                Factory<OneSequenceGestureRecognizer>(
+                  () => EagerGestureRecognizer(),
+                ),
+              },
+              markers: {
+                const Marker(
+                  markerId: MarkerId("store"),
+                  position: LatLng(37.6203769557633, 127.057749200082),
+                  // icon: viewModel.markerOffIcon!,
+                ),
+              },
+            ),
+          ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Flexible(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(
+                      'TODO: 가게 이름',
+                      style: KwangStyle.btn1SB,
+                    ),
+                    const SizedBox(height: 5),
+                    Text(
+                      'TODO: 가게 주소',
+                      style: KwangStyle.body2M,
+                    ),
+                  ],
+                ),
+              ),
+              SvgPicture.asset(
+                "assets/icons/ic_16_copy.svg",
+                width: 32,
+                height: 32,
+                colorFilter: const ColorFilter.mode(
+                  KwangColor.grey600,
+                  BlendMode.srcIn,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 26),
+      ],
+    );
+  }
+}

--- a/lib/screens/purchase_info/widgets/purchase_info_map.dart
+++ b/lib/screens/purchase_info/widgets/purchase_info_map.dart
@@ -106,7 +106,7 @@ class PurchaseInfoMap extends StatelessWidget {
             ],
           ),
         ),
-        const SizedBox(height: 26),
+        const SizedBox(height: 16),
       ],
     );
   }

--- a/lib/screens/purchase_info/widgets/purchase_info_map_detail.dart
+++ b/lib/screens/purchase_info/widgets/purchase_info_map_detail.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:immersion_kwangsang/screens/purchase_info/purchase_info_view_model.dart';
+import 'package:immersion_kwangsang/screens/purchase_info/widgets/purchase_info_card_h_spliter.dart';
+import 'package:immersion_kwangsang/styles/color.dart';
+import 'package:immersion_kwangsang/styles/txt.dart';
+import 'package:provider/provider.dart';
+
+class PurchaseInfoMapDetail extends StatelessWidget {
+  const PurchaseInfoMapDetail({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = Provider.of<PurchaseInfoViewModel>(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Column(
+        children: [
+          const PurchaseInfoCardHSpliter(size: 1),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '영업 시간',
+                style: KwangStyle.btn2SB,
+              ),
+              Text(
+                '10:00~21:00',
+                style: KwangStyle.btn2SB,
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '픽업 시간',
+                style: KwangStyle.btn2SB,
+              ),
+              Text(
+                '14~20분',
+                style: KwangStyle.btn2SB,
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '나와의 거리',
+                style: KwangStyle.btn2SB,
+              ),
+              Text(
+                '1.3km',
+                style: KwangStyle.btn2SB,
+              ),
+            ],
+          ),
+          const SizedBox(height: 18),
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: KwangColor.grey300,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  '매장 내에서 직접 픽업해주세요',
+                  style: KwangStyle.btn2B.copyWith(
+                    color: KwangColor.secondary100,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                _noticeText('주문이 승인된 후에는 주문 변경이나 취소가 불가합니다.'),
+                const SizedBox(height: 6),
+                _noticeText('픽업은 상품 준비 완료 이후 부터 가능합니다.'),
+                const SizedBox(height: 6),
+                _noticeText(
+                    '준비 완료된 음식은 00(시간/분) 동안 매장에서 보관되며 해당 시간 내 픽업하지 않을 경우 폐기됩니다.'),
+                const SizedBox(height: 6),
+                _noticeText('폐기 후 제재공 및 환불은 불가합니다.'),
+              ],
+            ),
+          ),
+          const SizedBox(height: 18),
+        ],
+      ),
+    );
+  }
+
+  Widget _noticeText(String message) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '•',
+          style: KwangStyle.body2M,
+        ),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            message,
+            style: KwangStyle.body2M,
+            maxLines: 999,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/purchase_info/widgets/purchase_info_method.dart
+++ b/lib/screens/purchase_info/widgets/purchase_info_method.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:immersion_kwangsang/styles/color.dart';
+import 'package:immersion_kwangsang/styles/txt.dart';
+
+class PurchaseInfoMethod extends StatelessWidget {
+  const PurchaseInfoMethod({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: 20,
+        vertical: 16,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const SizedBox(height: 8),
+          Text(
+            '결제 수단',
+            style: KwangStyle.header2,
+          ),
+          const SizedBox(height: 24),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '카드 결제',
+                style: KwangStyle.body1M.copyWith(
+                  color: KwangColor.grey800,
+                ),
+              ),
+              Text(
+                '우리카드 9820 2341 **** ****',
+                style: KwangStyle.body1M.copyWith(
+                  color: KwangColor.grey500,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/purchase_info/widgets/purchase_info_progress_widget.dart
+++ b/lib/screens/purchase_info/widgets/purchase_info_progress_widget.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:immersion_kwangsang/screens/purchase_info/purchase_info_view_model.dart';
+import 'package:immersion_kwangsang/styles/color.dart';
+import 'package:immersion_kwangsang/styles/txt.dart';
+import 'package:provider/provider.dart';
+
+class PurchaseInfoProgressWidget extends StatelessWidget {
+  const PurchaseInfoProgressWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = Provider.of<PurchaseInfoViewModel>(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: 20,
+            vertical: 16,
+          ),
+          child: Text(
+            viewModel.phase.phaseTitle,
+            style: KwangStyle.header2,
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(20),
+          child: CustomPaint(
+            size: Size(MediaQuery.sizeOf(context).width - 40, 40),
+            painter: _ProgressBarPainter(
+              width: MediaQuery.sizeOf(context).width - 40,
+              height: 40,
+              currentPhase: viewModel.phase,
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+      ],
+    );
+  }
+}
+
+class _ProgressBarPainter extends CustomPainter {
+  final double width;
+  final double height;
+  final EPurchaseInfoPhase currentPhase;
+
+  late final List<TextSpan> phaseTextSpan;
+
+  _ProgressBarPainter({
+    required this.width,
+    required this.height,
+    required this.currentPhase,
+  }) {
+    var isPassed = true;
+    List<TextSpan> textSpan = [];
+    for (var phase in EPurchaseInfoPhase.values) {
+      textSpan.add(
+        TextSpan(
+          text: phase.progressText,
+          style: KwangStyle.btn1SB.copyWith(
+            fontSize: 12,
+            color: isPassed ? KwangColor.grey900 : KwangColor.grey600,
+          ),
+        ),
+      );
+      if (phase == currentPhase) {
+        isPassed = false;
+      }
+    }
+    phaseTextSpan = textSpan;
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final phaseIdx = EPurchaseInfoPhase.values.indexOf(currentPhase);
+    final diffX = (width / (phaseTextSpan.length - 1));
+
+    // Paint base bar
+    var baseBarPaint = Paint()
+      ..color = KwangColor.primary50
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = 12;
+    var sOffset = const Offset(6, 6);
+    var eOffset = Offset(width - 6, 6);
+    canvas.drawLine(sOffset, eOffset, baseBarPaint);
+
+    // Paint progress bar
+    var progressBarPaint = Paint()
+      ..color = KwangColor.primary200
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = 12;
+    sOffset = const Offset(6, 6);
+    if (phaseIdx == phaseTextSpan.length - 1) {
+      eOffset = Offset(width - 6, 6);
+    } else {
+      var textPainter = TextPainter()
+        ..text = phaseTextSpan[phaseIdx]
+        ..textDirection = TextDirection.ltr
+        ..layout();
+      eOffset = Offset(
+        phaseIdx * diffX -
+            textPainter.width * (phaseIdx / (phaseTextSpan.length - 1)) +
+            textPainter.width / 2,
+        6,
+      );
+    }
+
+    canvas.drawLine(sOffset, eOffset, progressBarPaint);
+
+    var isPassed = true;
+    for (int phase = 0; phase < phaseTextSpan.length; phase++) {
+      // Paint text
+      var textPainter = TextPainter()
+        ..text = phaseTextSpan[phase]
+        ..textDirection = TextDirection.ltr
+        ..textAlign = TextAlign.center
+        ..layout();
+      var xCenter = phase * diffX -
+          textPainter.width * (phase / (phaseTextSpan.length - 1));
+      var yCenter = height - textPainter.height;
+      var offset = Offset(xCenter, yCenter);
+      textPainter.paint(canvas, offset);
+
+      // Paint dot
+      if (isPassed) {
+        var dotPaint = Paint()
+          ..color = KwangColor.primary300
+          ..strokeWidth = 8
+          ..style = PaintingStyle.stroke;
+        var dotOffset = Offset(offset.dx + textPainter.width / 2, 6);
+        canvas.drawCircle(dotOffset, 0, dotPaint);
+      } else {
+        var dotPaint = Paint()
+          ..color = KwangColor.primary100
+          ..strokeWidth = 10
+          ..style = PaintingStyle.stroke;
+        var dotOffset = Offset(offset.dx + textPainter.width / 2, 6);
+        canvas.drawCircle(dotOffset, 0, dotPaint);
+
+        dotPaint
+          ..color = KwangColor.primary200
+          ..strokeWidth = 6;
+        canvas.drawCircle(dotOffset, 0, dotPaint);
+      }
+
+      if (phase == phaseIdx) {
+        isPassed = false;
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    return false;
+  }
+}

--- a/lib/styles/color.dart
+++ b/lib/styles/color.dart
@@ -19,6 +19,8 @@ class KwangColor {
   static const primary300 = Color(0xFF587761);
   static const primary400 = Color(0xFF3D5D47);
 
+  static const secondary100 = Color(0xFF39997F);
+
   static const red = Color(0xFFEE3C32);
   static const orange = Color(0xFFFF8C22);
   static const blue = Color(0xFF2260FF);


### PR DESCRIPTION
### 개요

주문 내역 화면 4종 구현,
추가로 비 회원도 대응되는 화면 구현 완료했습니다.

Resolves: #25 

### 추가사항

- 주문 내역 - 주문 요청
- 주문 내역 - 주문 승인
- 주문 내역 - 픽업 대기
- 주문 내역 - 픽업 완료
- 상기 4 화면 비회원 대응

### 변경사항 및 이유

- menu_bottom_sheet_view
  임시로 주문하기 버튼을 누르면 라우팅되도록 하였습니다. 추후 변경 필요

- style/color
  secondary100 컬러를 추가했습니다.